### PR TITLE
Use setup-java action to cache dependencies

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+          cache: 'gradle'
       - name: Build with Gradle
         uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
         with:


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Description

Updated workflows to cache dependencies using [actions/setup-java](https://github.com/actions/setup-java#caching-packages-dependencies). `setup-java@v3` or newer has caching **built-in**.

### About caching workflow dependencies
Jobs on GitHub-hosted runners start in a clean virtual environment and **must download dependencies each time**, causing increased network utilization, longer runtime, and increased cost. To help speed up the time it takes to recreate files like dependencies, GitHub can cache files that frequently use in workflows.

### Solutions
Java projects can run faster on GitHub Actions by enabling dependency caching on the [setup-java](https://github.com/actions/setup-java) action. `setup-java` supports caching for both Gradle and Maven projects.

**AS-IS**

```yaml
- name: Set up JDK 17
  uses: actions/setup-java@v3
  with:
    java-version: '17'
    distribution: 'temurin'
```

**TO-BE**

```yaml
- name: Set up JDK 17
  uses: actions/setup-java@v3
  with:
    java-version: '17'
    distribution: 'temurin'
    cache: 'gradle'
```

> It’s literally a one line change to pass the `cache: 'gradle'` input parameter.

## References
[actions/setup-java#caching-packages-dependencies](https://github.com/actions/setup-java#caching-packages-dependencies)