### PR TITLE
Fix to not include IDE and macOS metadata in changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,84 +24,20 @@
 hs_err_pid*
 replay_pid*
 
-### JetBrains template
-# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
-# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
-
-# User-specific stuff
-.idea/**/workspace.xml
-.idea/**/tasks.xml
-.idea/**/usage.statistics.xml
-.idea/**/dictionaries
-.idea/**/shelf
-
-# AWS User-specific
-.idea/**/aws.xml
-
-# Generated files
-.idea/**/contentModel.xml
-
-# Sensitive or high-churn files
-.idea/**/dataSources/
-.idea/**/dataSources.ids
-.idea/**/dataSources.local.xml
-.idea/**/sqlDataSources.xml
-.idea/**/dynamic.xml
-.idea/**/uiDesigner.xml
-.idea/**/dbnavigator.xml
-
-# Gradle
-.idea/**/gradle.xml
-.idea/**/libraries
-
-# Gradle and Maven with auto-import
-# When using Gradle or Maven with auto-import, you should exclude module files,
-# since they will be recreated, and may cause churn.  Uncomment if using
-# auto-import.
-# .idea/artifacts
-# .idea/compiler.xml
-# .idea/jarRepositories.xml
-# .idea/modules.xml
-# .idea/*.iml
-# .idea/modules
-# *.iml
-# *.ipr
-
 # CMake
 cmake-build-*/
-
-# Mongo Explorer plugin
-.idea/**/mongoSettings.xml
 
 # File-based project format
 *.iws
 
-# IntelliJ
-out/
-
-# mpeltonen/sbt-idea plugin
-.idea_modules/
-
 # JIRA plugin
 atlassian-ide-plugin.xml
-
-# Cursive Clojure plugin
-.idea/replstate.xml
-
-# SonarLint plugin
-.idea/sonarlint/
 
 # Crashlytics plugin (for Android Studio and IntelliJ)
 com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 fabric.properties
-
-# Editor-based Rest Client
-.idea/httpRequests
-
-# Android studio 3.1+ serialized cache file
-.idea/caches/build_file_checksums.ser
 
 ### Gradle template
 .gradle
@@ -121,9 +57,34 @@ gradle-app.setting
 # Cache of project
 .gradletasknamecache
 
-# Eclipse Gradle plugin generated files
-# Eclipse Core
-.project
-# JDT-specific (Eclipse Java Development Tools)
-.classpath
+# IntelliJ
+.idea
+*.iml
+*.iws
+*.ipr
+*.ids
+*.orig
+/classes
+/out
 
+# VSCode
+/.vscode
+
+# Eclipse
+*.pydevproject
+.project
+.metadata
+/bin
+/*/bin
+/tmp
+/*/tmp
+*.tmp
+*.bak
+*.swp
+*~.nib
+.classpath
+.settings
+.loadpath
+
+# macOS folder metadata
+.DS_Store


### PR DESCRIPTION
Motivation:

<img width="218" alt="image" src="https://user-images.githubusercontent.com/37795866/209953586-9f9b895a-ec2b-4a5d-a8c4-9cc9a07482c3.png">

Not to include IDE and OS-specific metadata into changes

Modifications:

- Fix to not include IDE and macOS metadata in changes

Result:

- Metadata from 3 IDEs (IntelliJ, Eclipse, VSCode), macOS not reflected in changes.
- Referenced [.gitignore in line/armeria](https://github.com/line/armeria/blob/master/.gitignore
)

Additional info:

- If I belong to LINE, do I have to use my company email(**@linecorp.com**) as the commit author email when making open source contributions? I understand that it is okay to use a personal email for non-business contributions, but I need to confirm that.