### PR TITLE
Implement infix function

### DIFF
--- a/conditional-kotlin/src/main/kotlin/com/linecorp/conditional/kotlin/ConditionalExtension.kt
+++ b/conditional-kotlin/src/main/kotlin/com/linecorp/conditional/kotlin/ConditionalExtension.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.linecorp.conditional.kotlin
 
 import com.linecorp.conditional.ComposedCondition

--- a/conditional-kotlin/src/main/kotlin/com/linecorp/conditional/kotlin/ConditionalExtension.kt
+++ b/conditional-kotlin/src/main/kotlin/com/linecorp/conditional/kotlin/ConditionalExtension.kt
@@ -6,5 +6,3 @@ import com.linecorp.conditional.Condition
 infix fun Condition.and(condition: Condition): ComposedCondition = this.and(condition)
 
 infix fun Condition.or(condition: Condition): ComposedCondition = this.or(condition)
-
-infix fun Condition.nor(condition: Condition): ComposedCondition = this.nor(condition)

--- a/conditional-kotlin/src/main/kotlin/com/linecorp/conditional/kotlin/ConditionalExtension.kt
+++ b/conditional-kotlin/src/main/kotlin/com/linecorp/conditional/kotlin/ConditionalExtension.kt
@@ -1,0 +1,10 @@
+package com.linecorp.conditional.kotlin
+
+import com.linecorp.conditional.ComposedCondition
+import com.linecorp.conditional.Condition
+
+infix fun Condition.and(condition: Condition): ComposedCondition = this.and(condition)
+
+infix fun Condition.or(condition: Condition): ComposedCondition = this.or(condition)
+
+infix fun Condition.nor(condition: Condition): ComposedCondition = this.nor(condition)

--- a/conditional-kotlin/src/main/kotlin/com/linecorp/conditional/kotlin/ConditionalExtension.kt
+++ b/conditional-kotlin/src/main/kotlin/com/linecorp/conditional/kotlin/ConditionalExtension.kt
@@ -6,3 +6,5 @@ import com.linecorp.conditional.Condition
 infix fun Condition.and(condition: Condition): ComposedCondition = this.and(condition)
 
 infix fun Condition.or(condition: Condition): ComposedCondition = this.or(condition)
+
+operator fun Condition.not(): Condition = Condition.not(this)

--- a/conditional-kotlin/src/test/kotlin/com/linecorp/conditional/kotlin/ConditionalExtensionComposedConditionTest.kt
+++ b/conditional-kotlin/src/test/kotlin/com/linecorp/conditional/kotlin/ConditionalExtensionComposedConditionTest.kt
@@ -1,0 +1,158 @@
+package com.linecorp.conditional.kotlin
+
+import com.linecorp.conditional.Condition
+import com.linecorp.conditional.ConditionContext
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable
+import org.awaitility.Awaitility
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.*
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.stream.Stream
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class ConditionalExtensionComposedConditionTest {
+
+    companion object {
+        private val trueCondition = Condition.trueCondition()
+        private val falseCondition = Condition.falseCondition()
+        private val failed = Condition.failed { _: ConditionContext? -> RuntimeException() }
+    }
+
+    private fun AND(): Stream<Arguments?>? {
+        return Stream.of( // true and failed = exception raised
+            Arguments.of(
+                trueCondition and failed,
+                RuntimeException()::class.java, null
+            ),  // false and failed = false
+            Arguments.of(
+                falseCondition and failed,
+                null, false
+            ),  // false and (failed and true) = false
+            Arguments.of(
+                falseCondition and (failed and trueCondition),
+                null, false
+            ),  // (true and true) and failed = exception raised
+            Arguments.of(
+                (trueCondition and trueCondition) and failed,
+                RuntimeException()::class.java, null
+            ),  // (true and false) and failed = false
+            Arguments.of(
+                (trueCondition and falseCondition) and failed,
+                null, false
+            )
+        )
+    }
+
+    @ParameterizedTest
+    @MethodSource("AND")
+    @Throws(Throwable::class)
+    fun matches_when_operator_AND(
+        condition: Condition,
+        expectedException: Class<out Throwable?>?,
+        expectedMatches: Boolean?,
+    ) {
+        val ctx = ConditionContext.of()
+        val throwingCallable = ThrowingCallable { condition.matches(ctx) }
+        if (expectedException != null) {
+            Assertions.assertThatThrownBy(throwingCallable)
+                .isExactlyInstanceOf(expectedException)
+        } else {
+            Objects.requireNonNull(expectedMatches, "expectedMatches")
+            throwingCallable.call()
+        }
+    }
+
+    private fun OR(): Stream<Arguments?>? {
+        return Stream.of( // false or failed = exception raised
+            Arguments.of(
+                falseCondition or failed,
+                RuntimeException()::class.java, null
+            ),  // true or failed = true
+            Arguments.of(
+                trueCondition or failed,
+                null, true
+            ),  // true or (failed or false) = true
+            Arguments.of(
+                trueCondition or (failed or falseCondition),
+                null, true
+            ),  // (true or false) or failed = true
+            Arguments.of(
+                (trueCondition or falseCondition) or failed,
+                null, true
+            ),  // (false or false) or failed = exception raised
+            Arguments.of(
+                (falseCondition or falseCondition) or failed,
+                RuntimeException()::class.java, null
+            )
+        )
+    }
+
+    @ParameterizedTest
+    @MethodSource("OR")
+    @Throws(Throwable::class)
+    fun matches_when_operator_OR(
+        condition: Condition,
+        expectedException: Class<out Throwable?>?,
+        expectedMatches: Boolean?,
+    ) {
+        val ctx = ConditionContext.of()
+        val throwingCallable = ThrowingCallable { condition.matches(ctx) }
+        if (expectedException != null) {
+            Assertions.assertThatThrownBy(throwingCallable)
+                .isExactlyInstanceOf(expectedException)
+        } else {
+            Objects.requireNonNull(expectedMatches, "expectedMatches")
+            throwingCallable.call()
+        }
+    }
+
+    private fun SEQUENTIAL(): Stream<Arguments?>? {
+        val a = Condition.delayed({ _: ConditionContext? -> true }, 2000, TimeUnit.MILLISECONDS).alias("a")
+        val b = Condition.delayed({ _: ConditionContext? -> true }, 3000, TimeUnit.MILLISECONDS).alias("b")
+        return Stream.of(
+            Arguments.of((a and b).sequential(), 5000, 5500),
+            Arguments.of((a or b).sequential(), 2000, 2500)
+        )
+    }
+
+    @ParameterizedTest
+    @MethodSource("SEQUENTIAL")
+    fun sequential(condition: Condition, atLeastMillis: Long, atMostMillis: Long) {
+        val ctx = ConditionContext.of()
+        Awaitility.await().atLeast(atLeastMillis, TimeUnit.MILLISECONDS)
+            .atMost(atMostMillis, TimeUnit.MILLISECONDS)
+            .until {
+                Assertions.assertThat(condition.matches(ctx)).isTrue
+                true
+            }
+    }
+
+    private fun PARALLEL(): Stream<Arguments?>? {
+        val a = Condition.delayed({ _: ConditionContext? -> true }, 2000, TimeUnit.MILLISECONDS).alias("a")
+        val b = Condition.delayed({ _: ConditionContext? -> true }, 3000, TimeUnit.MILLISECONDS).alias("b")
+        val executor = Executors.newSingleThreadExecutor()
+        return Stream.of(
+            Arguments.of((a and b).parallel(), 3000, 3500),
+            Arguments.of((a or b).parallel(), 2000, 2500),
+            Arguments.of((a and b).parallel(executor), 5000, 5500),
+            Arguments.of((a or b).parallel(executor), 2000, 3500)
+        )
+    }
+
+    @ParameterizedTest
+    @MethodSource("PARALLEL")
+    fun parallel(condition: Condition, atLeastMillis: Long, atMostMillis: Long) {
+        val ctx = ConditionContext.of()
+        Awaitility.await().atLeast(atLeastMillis, TimeUnit.MILLISECONDS)
+            .atMost(atMostMillis, TimeUnit.MILLISECONDS)
+            .until {
+                Assertions.assertThat(condition.matches(ctx)).isTrue
+                true
+            }
+    }
+}

--- a/conditional-kotlin/src/test/kotlin/com/linecorp/conditional/kotlin/ConditionalExtensionComposedConditionTest.kt
+++ b/conditional-kotlin/src/test/kotlin/com/linecorp/conditional/kotlin/ConditionalExtensionComposedConditionTest.kt
@@ -5,7 +5,6 @@ import com.linecorp.conditional.ConditionContext
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable
 import org.awaitility.Awaitility
-import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -14,38 +13,87 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.stream.Stream
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class ConditionalExtensionComposedConditionTest {
 
     companion object {
         private val trueCondition = Condition.trueCondition()
         private val falseCondition = Condition.falseCondition()
         private val failed = Condition.failed { _: ConditionContext? -> RuntimeException() }
-    }
 
-    private fun AND(): Stream<Arguments?>? {
-        return Stream.of( // true and failed = exception raised
-            Arguments.of(
-                trueCondition and failed,
-                RuntimeException()::class.java, null
-            ),  // false and failed = false
-            Arguments.of(
-                falseCondition and failed,
-                null, false
-            ),  // false and (failed and true) = false
-            Arguments.of(
-                falseCondition and (failed and trueCondition),
-                null, false
-            ),  // (true and true) and failed = exception raised
-            Arguments.of(
-                (trueCondition and trueCondition) and failed,
-                RuntimeException()::class.java, null
-            ),  // (true and false) and failed = false
-            Arguments.of(
-                (trueCondition and falseCondition) and failed,
-                null, false
+        @JvmStatic
+        private fun AND(): Stream<Arguments?>? {
+            return Stream.of( // true and failed = exception raised
+                Arguments.of(
+                    trueCondition and failed,
+                    RuntimeException()::class.java, null
+                ),  // false and failed = false
+                Arguments.of(
+                    falseCondition and failed,
+                    null, false
+                ),  // false and (failed and true) = false
+                Arguments.of(
+                    falseCondition and (failed and trueCondition),
+                    null, false
+                ),  // (true and true) and failed = exception raised
+                Arguments.of(
+                    (trueCondition and trueCondition) and failed,
+                    RuntimeException()::class.java, null
+                ),  // (true and false) and failed = false
+                Arguments.of(
+                    (trueCondition and falseCondition) and failed,
+                    null, false
+                )
             )
-        )
+        }
+
+        @JvmStatic
+        private fun OR(): Stream<Arguments?>? {
+            return Stream.of( // false or failed = exception raised
+                Arguments.of(
+                    falseCondition or failed,
+                    RuntimeException()::class.java, null
+                ),  // true or failed = true
+                Arguments.of(
+                    trueCondition or failed,
+                    null, true
+                ),  // true or (failed or false) = true
+                Arguments.of(
+                    trueCondition or (failed or falseCondition),
+                    null, true
+                ),  // (true or false) or failed = true
+                Arguments.of(
+                    (trueCondition or falseCondition) or failed,
+                    null, true
+                ),  // (false or false) or failed = exception raised
+                Arguments.of(
+                    (falseCondition or falseCondition) or failed,
+                    RuntimeException()::class.java, null
+                )
+            )
+        }
+
+        @JvmStatic
+        private fun SEQUENTIAL(): Stream<Arguments?>? {
+            val a = Condition.delayed({ _: ConditionContext? -> true }, 2000, TimeUnit.MILLISECONDS).alias("a")
+            val b = Condition.delayed({ _: ConditionContext? -> true }, 3000, TimeUnit.MILLISECONDS).alias("b")
+            return Stream.of(
+                Arguments.of((a and b).sequential(), 5000, 5500),
+                Arguments.of((a or b).sequential(), 2000, 2500)
+            )
+        }
+
+        @JvmStatic
+        private fun PARALLEL(): Stream<Arguments?>? {
+            val a = Condition.delayed({ _: ConditionContext? -> true }, 2000, TimeUnit.MILLISECONDS).alias("a")
+            val b = Condition.delayed({ _: ConditionContext? -> true }, 3000, TimeUnit.MILLISECONDS).alias("b")
+            val executor = Executors.newSingleThreadExecutor()
+            return Stream.of(
+                Arguments.of((a and b).parallel(), 3000, 3500),
+                Arguments.of((a or b).parallel(), 2000, 2500),
+                Arguments.of((a and b).parallel(executor), 5000, 5500),
+                Arguments.of((a or b).parallel(executor), 2000, 3500)
+            )
+        }
     }
 
     @ParameterizedTest
@@ -67,31 +115,6 @@ internal class ConditionalExtensionComposedConditionTest {
         }
     }
 
-    private fun OR(): Stream<Arguments?>? {
-        return Stream.of( // false or failed = exception raised
-            Arguments.of(
-                falseCondition or failed,
-                RuntimeException()::class.java, null
-            ),  // true or failed = true
-            Arguments.of(
-                trueCondition or failed,
-                null, true
-            ),  // true or (failed or false) = true
-            Arguments.of(
-                trueCondition or (failed or falseCondition),
-                null, true
-            ),  // (true or false) or failed = true
-            Arguments.of(
-                (trueCondition or falseCondition) or failed,
-                null, true
-            ),  // (false or false) or failed = exception raised
-            Arguments.of(
-                (falseCondition or falseCondition) or failed,
-                RuntimeException()::class.java, null
-            )
-        )
-    }
-
     @ParameterizedTest
     @MethodSource("OR")
     @Throws(Throwable::class)
@@ -111,15 +134,6 @@ internal class ConditionalExtensionComposedConditionTest {
         }
     }
 
-    private fun SEQUENTIAL(): Stream<Arguments?>? {
-        val a = Condition.delayed({ _: ConditionContext? -> true }, 2000, TimeUnit.MILLISECONDS).alias("a")
-        val b = Condition.delayed({ _: ConditionContext? -> true }, 3000, TimeUnit.MILLISECONDS).alias("b")
-        return Stream.of(
-            Arguments.of((a and b).sequential(), 5000, 5500),
-            Arguments.of((a or b).sequential(), 2000, 2500)
-        )
-    }
-
     @ParameterizedTest
     @MethodSource("SEQUENTIAL")
     fun sequential(condition: Condition, atLeastMillis: Long, atMostMillis: Long) {
@@ -130,18 +144,6 @@ internal class ConditionalExtensionComposedConditionTest {
                 Assertions.assertThat(condition.matches(ctx)).isTrue
                 true
             }
-    }
-
-    private fun PARALLEL(): Stream<Arguments?>? {
-        val a = Condition.delayed({ _: ConditionContext? -> true }, 2000, TimeUnit.MILLISECONDS).alias("a")
-        val b = Condition.delayed({ _: ConditionContext? -> true }, 3000, TimeUnit.MILLISECONDS).alias("b")
-        val executor = Executors.newSingleThreadExecutor()
-        return Stream.of(
-            Arguments.of((a and b).parallel(), 3000, 3500),
-            Arguments.of((a or b).parallel(), 2000, 2500),
-            Arguments.of((a and b).parallel(executor), 5000, 5500),
-            Arguments.of((a or b).parallel(executor), 2000, 3500)
-        )
     }
 
     @ParameterizedTest

--- a/conditional-kotlin/src/test/kotlin/com/linecorp/conditional/kotlin/ConditionalExtensionComposedConditionTest.kt
+++ b/conditional-kotlin/src/test/kotlin/com/linecorp/conditional/kotlin/ConditionalExtensionComposedConditionTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.linecorp.conditional.kotlin
 
 import com.linecorp.conditional.Condition

--- a/conditional-kotlin/src/test/kotlin/com/linecorp/conditional/kotlin/ConditionalExtensionComposedConditionTest.kt
+++ b/conditional-kotlin/src/test/kotlin/com/linecorp/conditional/kotlin/ConditionalExtensionComposedConditionTest.kt
@@ -18,14 +18,14 @@ internal class ConditionalExtensionComposedConditionTest {
     companion object {
         private val trueCondition = Condition.trueCondition()
         private val falseCondition = Condition.falseCondition()
-        private val failed = Condition.failed { _: ConditionContext? -> RuntimeException() }
+        private val failed = Condition.failed { _: ConditionContext -> RuntimeException() }
 
         @JvmStatic
-        private fun AND(): Stream<Arguments?>? {
+        private fun AND(): Stream<Arguments> {
             return Stream.of( // true and failed = exception raised
                 Arguments.of(
                     trueCondition and failed,
-                    RuntimeException()::class.java, null
+                    RuntimeException::class.java, null
                 ),  // false and failed = false
                 Arguments.of(
                     falseCondition and failed,
@@ -37,7 +37,7 @@ internal class ConditionalExtensionComposedConditionTest {
                 ),  // (true and true) and failed = exception raised
                 Arguments.of(
                     (trueCondition and trueCondition) and failed,
-                    RuntimeException()::class.java, null
+                    RuntimeException::class.java, null
                 ),  // (true and false) and failed = false
                 Arguments.of(
                     (trueCondition and falseCondition) and failed,
@@ -47,11 +47,11 @@ internal class ConditionalExtensionComposedConditionTest {
         }
 
         @JvmStatic
-        private fun OR(): Stream<Arguments?>? {
+        private fun OR(): Stream<Arguments> {
             return Stream.of( // false or failed = exception raised
                 Arguments.of(
                     falseCondition or failed,
-                    RuntimeException()::class.java, null
+                    RuntimeException::class.java, null
                 ),  // true or failed = true
                 Arguments.of(
                     trueCondition or failed,
@@ -67,15 +67,15 @@ internal class ConditionalExtensionComposedConditionTest {
                 ),  // (false or false) or failed = exception raised
                 Arguments.of(
                     (falseCondition or falseCondition) or failed,
-                    RuntimeException()::class.java, null
+                    RuntimeException::class.java, null
                 )
             )
         }
 
         @JvmStatic
-        private fun SEQUENTIAL(): Stream<Arguments?>? {
-            val a = Condition.delayed({ _: ConditionContext? -> true }, 2000, TimeUnit.MILLISECONDS).alias("a")
-            val b = Condition.delayed({ _: ConditionContext? -> true }, 3000, TimeUnit.MILLISECONDS).alias("b")
+        private fun SEQUENTIAL(): Stream<Arguments> {
+            val a = Condition.delayed({ _: ConditionContext -> true }, 2000, TimeUnit.MILLISECONDS).alias("a")
+            val b = Condition.delayed({ _: ConditionContext -> true }, 3000, TimeUnit.MILLISECONDS).alias("b")
             return Stream.of(
                 Arguments.of((a and b).sequential(), 5000, 5500),
                 Arguments.of((a or b).sequential(), 2000, 2500)
@@ -83,9 +83,9 @@ internal class ConditionalExtensionComposedConditionTest {
         }
 
         @JvmStatic
-        private fun PARALLEL(): Stream<Arguments?>? {
-            val a = Condition.delayed({ _: ConditionContext? -> true }, 2000, TimeUnit.MILLISECONDS).alias("a")
-            val b = Condition.delayed({ _: ConditionContext? -> true }, 3000, TimeUnit.MILLISECONDS).alias("b")
+        private fun PARALLEL(): Stream<Arguments> {
+            val a = Condition.delayed({ _: ConditionContext -> true }, 2000, TimeUnit.MILLISECONDS).alias("a")
+            val b = Condition.delayed({ _: ConditionContext -> true }, 3000, TimeUnit.MILLISECONDS).alias("b")
             val executor = Executors.newSingleThreadExecutor()
             return Stream.of(
                 Arguments.of((a and b).parallel(), 3000, 3500),
@@ -101,7 +101,7 @@ internal class ConditionalExtensionComposedConditionTest {
     @Throws(Throwable::class)
     fun matches_when_operator_AND(
         condition: Condition,
-        expectedException: Class<out Throwable?>?,
+        expectedException: Class<out Throwable>?,
         expectedMatches: Boolean?,
     ) {
         val ctx = ConditionContext.of()
@@ -120,7 +120,7 @@ internal class ConditionalExtensionComposedConditionTest {
     @Throws(Throwable::class)
     fun matches_when_operator_OR(
         condition: Condition,
-        expectedException: Class<out Throwable?>?,
+        expectedException: Class<out Throwable>?,
         expectedMatches: Boolean?,
     ) {
         val ctx = ConditionContext.of()

--- a/conditional-kotlin/src/test/kotlin/com/linecorp/conditional/kotlin/ConditionalExtensionNotConditionTest.kt
+++ b/conditional-kotlin/src/test/kotlin/com/linecorp/conditional/kotlin/ConditionalExtensionNotConditionTest.kt
@@ -1,0 +1,24 @@
+package com.linecorp.conditional.kotlin
+
+import com.linecorp.conditional.Condition
+import com.linecorp.conditional.ConditionContext
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+internal class ConditionalExtensionNotConditionTest {
+
+    @Test
+    fun operator_NOT() {
+        assertThat(!trueCondition.matches(ConditionContext.of())).isFalse
+        assertThat(!falseCondition.matches(ConditionContext.of())).isTrue
+        assertThatThrownBy { !failed.matches(ConditionContext.of()) }
+            .isExactlyInstanceOf(RuntimeException::class.java)
+    }
+
+    companion object {
+        private val trueCondition = Condition.trueCondition()
+        private val falseCondition = Condition.falseCondition()
+        private val failed = Condition.failed { _: ConditionContext -> RuntimeException() }
+    }
+}

--- a/conditional-kotlin/src/test/kotlin/com/linecorp/conditional/kotlin/ConditionalExtensionNotConditionTest.kt
+++ b/conditional-kotlin/src/test/kotlin/com/linecorp/conditional/kotlin/ConditionalExtensionNotConditionTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.linecorp.conditional.kotlin
 
 import com.linecorp.conditional.Condition

--- a/conditional/src/test/java/com/linecorp/conditional/ComposableConditionTest.java
+++ b/conditional/src/test/java/com/linecorp/conditional/ComposableConditionTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.linecorp.conditional;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/conditional/src/test/java/com/linecorp/conditional/ComposedConditionAttributeUpdaterTest.java
+++ b/conditional/src/test/java/com/linecorp/conditional/ComposedConditionAttributeUpdaterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.linecorp.conditional;
 
 import static com.linecorp.conditional.Condition.falseCondition;

--- a/conditional/src/test/java/com/linecorp/conditional/ConditionAttributeUpdaterTest.java
+++ b/conditional/src/test/java/com/linecorp/conditional/ConditionAttributeUpdaterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.linecorp.conditional;
 
 import static com.linecorp.conditional.Condition.trueCondition;


### PR DESCRIPTION
Motivation:

Added infix function for `and` and `or`, which are representative operators of Condition, to the module for Kotlin support

Modifications:

- Implement infix function

Result:

- It is possible to use the infix function that operates the same as the existing `Condition.and()` and `Condition.or()`

### Using Java
```java
var a = Condition.of(ctx -> ctx.var("a", Boolean.class));
var b = Condition.of(ctx -> ctx.var("b", Boolean.class));
var andCondition = a.and(b);
var orCondition = a.or(b);
```

### Using Kotlin
```Kotlin
    val a = Condition.of { ctx: ConditionContext ->
        ctx.`var`(
            "a",
            Boolean::class.java
        )
    }
    val b = Condition.of { ctx: ConditionContext ->
        ctx.`var`(
            "b",
            Boolean::class.java
        )
    }
    val andCondition = a and b
    val orCondition = a or b
```

Additional info:

- If I belong to LINE, do I have to use my company email(**@linecorp.com**) as the commit author email when making open source contributions? I understand that it is okay to use a personal email for non-business contributions, but I need to confirm that.
- First of all, I didn't write test code.
I'm not sure how to write it because the function is so clear that I used the previously implemented function as it is.
If you have any ideas for writing test code, please comment 🙂 
