### PR TITLE
Move companion object block to bottom of the class

### DIFF
--- a/conditional-kotlin/src/test/kotlin/com/linecorp/conditional/kotlin/ConditionalExtensionComposedConditionTest.kt
+++ b/conditional-kotlin/src/test/kotlin/com/linecorp/conditional/kotlin/ConditionalExtensionComposedConditionTest.kt
@@ -31,7 +31,69 @@ import java.util.stream.Stream
 
 internal class ConditionalExtensionComposedConditionTest {
 
-    companion object {
+    @ParameterizedTest
+    @MethodSource("AND")
+    @Throws(Throwable::class)
+    fun matches_when_operator_AND(
+        condition: Condition,
+        expectedException: Class<out Throwable>?,
+        expectedMatches: Boolean?,
+    ) {
+        val ctx = ConditionContext.of()
+        val throwingCallable = ThrowingCallable { condition.matches(ctx) }
+        if (expectedException != null) {
+            Assertions.assertThatThrownBy(throwingCallable)
+                .isExactlyInstanceOf(expectedException)
+        } else {
+            Objects.requireNonNull(expectedMatches, "expectedMatches")
+            throwingCallable.call()
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("OR")
+    @Throws(Throwable::class)
+    fun matches_when_operator_OR(
+        condition: Condition,
+        expectedException: Class<out Throwable>?,
+        expectedMatches: Boolean?,
+    ) {
+        val ctx = ConditionContext.of()
+        val throwingCallable = ThrowingCallable { condition.matches(ctx) }
+        if (expectedException != null) {
+            Assertions.assertThatThrownBy(throwingCallable)
+                .isExactlyInstanceOf(expectedException)
+        } else {
+            Objects.requireNonNull(expectedMatches, "expectedMatches")
+            throwingCallable.call()
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("SEQUENTIAL")
+    fun sequential(condition: Condition, atLeastMillis: Long, atMostMillis: Long) {
+        val ctx = ConditionContext.of()
+        Awaitility.await().atLeast(atLeastMillis, TimeUnit.MILLISECONDS)
+            .atMost(atMostMillis, TimeUnit.MILLISECONDS)
+            .until {
+                Assertions.assertThat(condition.matches(ctx)).isTrue
+                true
+            }
+    }
+
+    @ParameterizedTest
+    @MethodSource("PARALLEL")
+    fun parallel(condition: Condition, atLeastMillis: Long, atMostMillis: Long) {
+        val ctx = ConditionContext.of()
+        Awaitility.await().atLeast(atLeastMillis, TimeUnit.MILLISECONDS)
+            .atMost(atMostMillis, TimeUnit.MILLISECONDS)
+            .until {
+                Assertions.assertThat(condition.matches(ctx)).isTrue
+                true
+            }
+    }
+
+    private companion object {
         private val trueCondition = Condition.trueCondition()
         private val falseCondition = Condition.falseCondition()
         private val failed = Condition.failed { _: ConditionContext -> RuntimeException() }
@@ -110,67 +172,5 @@ internal class ConditionalExtensionComposedConditionTest {
                 Arguments.of((a or b).parallel(executor), 2000, 3500)
             )
         }
-    }
-
-    @ParameterizedTest
-    @MethodSource("AND")
-    @Throws(Throwable::class)
-    fun matches_when_operator_AND(
-        condition: Condition,
-        expectedException: Class<out Throwable>?,
-        expectedMatches: Boolean?,
-    ) {
-        val ctx = ConditionContext.of()
-        val throwingCallable = ThrowingCallable { condition.matches(ctx) }
-        if (expectedException != null) {
-            Assertions.assertThatThrownBy(throwingCallable)
-                .isExactlyInstanceOf(expectedException)
-        } else {
-            Objects.requireNonNull(expectedMatches, "expectedMatches")
-            throwingCallable.call()
-        }
-    }
-
-    @ParameterizedTest
-    @MethodSource("OR")
-    @Throws(Throwable::class)
-    fun matches_when_operator_OR(
-        condition: Condition,
-        expectedException: Class<out Throwable>?,
-        expectedMatches: Boolean?,
-    ) {
-        val ctx = ConditionContext.of()
-        val throwingCallable = ThrowingCallable { condition.matches(ctx) }
-        if (expectedException != null) {
-            Assertions.assertThatThrownBy(throwingCallable)
-                .isExactlyInstanceOf(expectedException)
-        } else {
-            Objects.requireNonNull(expectedMatches, "expectedMatches")
-            throwingCallable.call()
-        }
-    }
-
-    @ParameterizedTest
-    @MethodSource("SEQUENTIAL")
-    fun sequential(condition: Condition, atLeastMillis: Long, atMostMillis: Long) {
-        val ctx = ConditionContext.of()
-        Awaitility.await().atLeast(atLeastMillis, TimeUnit.MILLISECONDS)
-            .atMost(atMostMillis, TimeUnit.MILLISECONDS)
-            .until {
-                Assertions.assertThat(condition.matches(ctx)).isTrue
-                true
-            }
-    }
-
-    @ParameterizedTest
-    @MethodSource("PARALLEL")
-    fun parallel(condition: Condition, atLeastMillis: Long, atMostMillis: Long) {
-        val ctx = ConditionContext.of()
-        Awaitility.await().atLeast(atLeastMillis, TimeUnit.MILLISECONDS)
-            .atMost(atMostMillis, TimeUnit.MILLISECONDS)
-            .until {
-                Assertions.assertThat(condition.matches(ctx)).isTrue
-                true
-            }
     }
 }

--- a/conditional-kotlin/src/test/kotlin/com/linecorp/conditional/kotlin/ConditionalExtensionNotConditionTest.kt
+++ b/conditional-kotlin/src/test/kotlin/com/linecorp/conditional/kotlin/ConditionalExtensionNotConditionTest.kt
@@ -32,7 +32,7 @@ internal class ConditionalExtensionNotConditionTest {
             .isExactlyInstanceOf(RuntimeException::class.java)
     }
 
-    companion object {
+    private companion object {
         private val trueCondition = Condition.trueCondition()
         private val falseCondition = Condition.falseCondition()
         private val failed = Condition.failed { _: ConditionContext -> RuntimeException() }


### PR DESCRIPTION
Motivation:

Relocation of companion object block according to [Kotlin Style Guide](https://github.com/Kotlin/kotlin-style-guide/issues/5)

Modifications:

- Move companion object block to bottom of the class

Result:

- Now companion object block is located to bottom of the class

Additional info:

- In fact, when I look at the current test code, I think it's okay from the point of view of understanding the code that the variable is located at the top.
- However, since there is no clear project convention for this yet, I followed the [Kotlin Style Guide](https://github.com/Kotlin/kotlin-style-guide/issues/5) and moved the companion object block to the bottom of the class.