### PR TITLE
Build a Kotlin DSL related to Condition

### DIFF
--- a/conditional-kotlin/src/main/kotlin/com/linecorp/conditional/kotlin/ConditionalExtension.kt
+++ b/conditional-kotlin/src/main/kotlin/com/linecorp/conditional/kotlin/ConditionalExtension.kt
@@ -17,59 +17,103 @@
 package com.linecorp.conditional.kotlin
 
 import com.linecorp.conditional.*
-import java.util.concurrent.Executor
 import java.util.concurrent.TimeUnit
 
+/**
+ * Returns a newly created [ComposedCondition].
+ * This [ComposedCondition] is composed with the AND operator.
+ *
+ * @param condition the [Condition] to compose.
+ *
+ * @throws NullPointerException if the [condition] is null.
+ */
 infix fun Condition.and(condition: Condition): ComposedCondition = and(condition)
+
+/**
+ * Returns a newly created [ComposedCondition].
+ * This [ComposedCondition] is composed with the OR operator.
+ *
+ * @param condition the [Condition] to compose.
+ *
+ * @throws NullPointerException if the [condition] is null.
+ */
 infix fun Condition.or(condition: Condition): ComposedCondition = or(condition)
+
+/**
+ * Returns a newly created negative [Condition].
+ *
+ * @throws NullPointerException if the [condition] is null.
+ */
 operator fun Condition.not(): Condition = Condition.not(this)
 
+/**
+ * Returns a newly created [Condition].
+ *
+ * @param function the function to match the conditional expression.
+ *
+ * @throws NullPointerException if the [function] is null.
+ */
 fun condition(function: ConditionFunction): Condition = Condition.of(function)
+
+/**
+ * Returns a newly created [Condition].
+ *
+ * @param timeoutMillis the value to set timeout for the [function].
+ * @param function the function to match the conditional expression.
+ *
+ * @throws NullPointerException if the [function] is null.
+ */
 fun condition(timeoutMillis: Long, function: ConditionFunction): Condition =
     Condition.of(function, timeoutMillis)
 
+/**
+ * Returns a newly created [Condition].
+ *
+ * @param timeout the value to set timeout for the [function].
+ * @param unit the unit to set timeout for the [function].
+ * @param function the function to match the conditional expression.
+ *
+ * @throws NullPointerException if [function] or [unit] is null.
+ */
 fun condition(timeout: Long, unit: TimeUnit, function: ConditionFunction): Condition =
     Condition.of(function, timeout, unit)
 
+/**
+ * Returns a newly created [Condition] by [Boolean] value.
+ */
 fun Boolean.asCondition(): Condition = condition { this }
-fun asyncCondition(function: ConditionFunction): Condition = Condition.async(function)
-fun asyncCondition(executor: Executor, function: ConditionFunction): Condition =
-    Condition.async(function, executor)
 
-fun asyncCondition(timeoutMillis: Long, function: ConditionFunction): Condition =
-    Condition.async(function, timeoutMillis)
-
-fun asyncCondition(timeoutMillis: Long, executor: Executor, function: ConditionFunction): Condition =
-    Condition.async(function, timeoutMillis, executor)
-
-fun asyncCondition(timeout: Long, unit: TimeUnit, function: ConditionFunction): Condition =
-    Condition.async(function, timeout, unit)
-
-fun asyncCondition(timeout: Long, unit: TimeUnit, executor: Executor, function: ConditionFunction): Condition =
-    Condition.async(function, timeout, unit, executor)
-
-fun Boolean.asAsyncCondition(): Condition = asyncCondition { this }
-fun Boolean.asAsyncCondition(executor: Executor): Condition = asyncCondition(executor) { this }
-fun delayedCondition(delayMillis: Long, function: ConditionFunction): Condition =
-    Condition.delayed(function, delayMillis)
-
-fun delayedCondition(delay: Long, unit: TimeUnit, function: ConditionFunction): Condition =
-    Condition.delayed(function, delay, unit)
-
-fun Boolean.asDelayedCondition(delayMillis: Long): Condition = delayedCondition(delayMillis) { this }
-fun Boolean.asDelayedCondition(delay: Long, unit: TimeUnit): Condition = delayedCondition(delay, unit) { this }
-
+/**
+ * Returns the [ConditionComposer].
+ *
+ * @param operator the operator of [ComposedCondition].
+ *
+ * @throws NullPointerException if the [operator] is null.
+ */
 fun conditionComposer(operator: Operator): ConditionComposer = Condition.composer(operator)
 
-fun completed(value: Boolean): Condition = Condition.completed(value)
+/**
+ * Returns a newly created [Condition] with true.
+ */
 fun `true`(): Condition = Condition.trueCondition()
-fun `false`(): Condition = Condition.falseCondition()
-fun <T : Throwable> failed(exceptionSupplier: () -> T): Condition = Condition.failed(exceptionSupplier)
-fun <T : Throwable> failed(exceptionSupplier: ConditionContextAwareSupplier<T>): Condition =
-    Condition.failed(exceptionSupplier)
 
+/**
+ * Returns a newly created [Condition] with false.
+ */
+fun `false`(): Condition = Condition.falseCondition()
+
+/**
+ * Returns a newly created [ConditionContext].
+ */
 fun conditionContext(): ConditionContext = ConditionContext.of()
+
+/**
+ * Returns a newly created [ConditionContext] by [contextVariables].
+ */
 fun conditionContext(contextVariables: Map<String, Any>): ConditionContext =
     ConditionContext.of(contextVariables)
 
+/**
+ * Returns a newly created [ConditionContext] by [this].
+ */
 fun Map<String, Any>.asConditionContext(): ConditionContext = conditionContext(this)

--- a/conditional-kotlin/src/main/kotlin/com/linecorp/conditional/kotlin/ConditionalExtension.kt
+++ b/conditional-kotlin/src/main/kotlin/com/linecorp/conditional/kotlin/ConditionalExtension.kt
@@ -16,11 +16,60 @@
 
 package com.linecorp.conditional.kotlin
 
-import com.linecorp.conditional.ComposedCondition
-import com.linecorp.conditional.Condition
+import com.linecorp.conditional.*
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
 
-infix fun Condition.and(condition: Condition): ComposedCondition = this.and(condition)
-
-infix fun Condition.or(condition: Condition): ComposedCondition = this.or(condition)
-
+infix fun Condition.and(condition: Condition): ComposedCondition = and(condition)
+infix fun Condition.or(condition: Condition): ComposedCondition = or(condition)
 operator fun Condition.not(): Condition = Condition.not(this)
+
+fun condition(function: ConditionFunction): Condition = Condition.of(function)
+fun condition(timeoutMillis: Long, function: ConditionFunction): Condition =
+    Condition.of(function, timeoutMillis)
+
+fun condition(timeout: Long, unit: TimeUnit, function: ConditionFunction): Condition =
+    Condition.of(function, timeout, unit)
+
+fun Boolean.asCondition(): Condition = condition { this }
+fun asyncCondition(function: ConditionFunction): Condition = Condition.async(function)
+fun asyncCondition(executor: Executor, function: ConditionFunction): Condition =
+    Condition.async(function, executor)
+
+fun asyncCondition(timeoutMillis: Long, function: ConditionFunction): Condition =
+    Condition.async(function, timeoutMillis)
+
+fun asyncCondition(timeoutMillis: Long, executor: Executor, function: ConditionFunction): Condition =
+    Condition.async(function, timeoutMillis, executor)
+
+fun asyncCondition(timeout: Long, unit: TimeUnit, function: ConditionFunction): Condition =
+    Condition.async(function, timeout, unit)
+
+fun asyncCondition(timeout: Long, unit: TimeUnit, executor: Executor, function: ConditionFunction): Condition =
+    Condition.async(function, timeout, unit, executor)
+
+fun Boolean.asAsyncCondition(): Condition = asyncCondition { this }
+fun Boolean.asAsyncCondition(executor: Executor): Condition = asyncCondition(executor) { this }
+fun delayedCondition(delayMillis: Long, function: ConditionFunction): Condition =
+    Condition.delayed(function, delayMillis)
+
+fun delayedCondition(delay: Long, unit: TimeUnit, function: ConditionFunction): Condition =
+    Condition.delayed(function, delay, unit)
+
+fun Boolean.asDelayedCondition(delayMillis: Long): Condition = delayedCondition(delayMillis) { this }
+fun Boolean.asDelayedCondition(delay: Long, unit: TimeUnit): Condition = delayedCondition(delay, unit) { this }
+
+fun conditionComposer(operator: Operator): ConditionComposer = Condition.composer(operator)
+
+fun completed(value: Boolean): Condition = Condition.completed(value)
+fun `true`(): Condition = Condition.trueCondition()
+fun `false`(): Condition = Condition.falseCondition()
+fun <T : Throwable> failed(exceptionSupplier: () -> T): Condition = Condition.failed(exceptionSupplier)
+fun <T : Throwable> failed(exceptionSupplier: ConditionContextAwareSupplier<T>): Condition =
+    Condition.failed(exceptionSupplier)
+
+fun conditionContext(): ConditionContext = ConditionContext.of()
+fun conditionContext(contextVariables: Map<String, Any>): ConditionContext =
+    ConditionContext.of(contextVariables)
+
+fun Map<String, Any>.asConditionContext(): ConditionContext = conditionContext(this)

--- a/conditional-kotlin/src/main/kotlin/com/linecorp/conditional/kotlin/ConditionalExtension.kt
+++ b/conditional-kotlin/src/main/kotlin/com/linecorp/conditional/kotlin/ConditionalExtension.kt
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit
  *
  * @throws NullPointerException if the [condition] is null.
  */
-infix fun Condition.and(condition: Condition): ComposedCondition = and(condition)
+infix fun Condition.and(condition: Condition): ComposedCondition = this.and(condition)
 
 /**
  * Returns a newly created [ComposedCondition].
@@ -37,7 +37,7 @@ infix fun Condition.and(condition: Condition): ComposedCondition = and(condition
  *
  * @throws NullPointerException if the [condition] is null.
  */
-infix fun Condition.or(condition: Condition): ComposedCondition = or(condition)
+infix fun Condition.or(condition: Condition): ComposedCondition = this.or(condition)
 
 /**
  * Returns a newly created negative [Condition].

--- a/conditional-kotlin/src/test/kotlin/com/linecorp/conditional/kotlin/ConditionalExtensionKtTest.kt
+++ b/conditional-kotlin/src/test/kotlin/com/linecorp/conditional/kotlin/ConditionalExtensionKtTest.kt
@@ -18,9 +18,7 @@ package com.linecorp.conditional.kotlin
 
 import com.linecorp.conditional.Operator
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
-import java.util.concurrent.ForkJoinPool
 import java.util.concurrent.TimeUnit
 
 class ConditionalExtensionKtTest {
@@ -54,104 +52,9 @@ class ConditionalExtensionKtTest {
     }
 
     @Test
-    fun asyncCondition() {
-        val condition = asyncCondition { true }
-        val ctx = conditionContext()
-        assertThat(condition.matches(ctx)).isTrue
-    }
-
-    @Test
-    fun asyncCondition_with_executor() {
-        val executor = ForkJoinPool.commonPool()
-        val condition = asyncCondition(executor) { true }
-        val ctx = conditionContext()
-        assertThat(condition.matches(ctx)).isTrue
-    }
-
-    @Test
-    fun asyncCondition_with_timeoutMillis() {
-        val condition = asyncCondition(1000) { true }
-        val ctx = conditionContext()
-        assertThat(condition.matches(ctx)).isTrue
-    }
-
-    @Test
-    fun asyncCondition_with_timeoutMillis_and_executor() {
-        val executor = ForkJoinPool.commonPool()
-        val condition = asyncCondition(1000, executor) { true }
-        val ctx = conditionContext()
-        assertThat(condition.matches(ctx)).isTrue
-    }
-
-    @Test
-    fun asyncCondition_with_timeout() {
-        val condition = asyncCondition(1000, TimeUnit.MILLISECONDS) { true }
-        val ctx = conditionContext()
-        assertThat(condition.matches(ctx)).isTrue
-    }
-
-    @Test
-    fun asyncCondition_with_timeout_and_executor() {
-        val executor = ForkJoinPool.commonPool()
-        val condition = asyncCondition(1000, TimeUnit.MILLISECONDS, executor) { true }
-        val ctx = conditionContext()
-        assertThat(condition.matches(ctx)).isTrue
-    }
-
-    @Test
-    fun asAsyncCondition() {
-        val condition = true.asAsyncCondition()
-        val ctx = conditionContext()
-        assertThat(condition.matches(ctx)).isTrue
-    }
-
-    @Test
-    fun asAsyncCondition_with_executor() {
-        val executor = ForkJoinPool.commonPool()
-        val condition = true.asAsyncCondition(executor)
-        val ctx = conditionContext()
-        assertThat(condition.matches(ctx)).isTrue
-    }
-
-    @Test
-    fun delayedCondition_with_delayMillis() {
-        val condition = delayedCondition(1000) { true }
-        val ctx = conditionContext()
-        assertThat(condition.matches(ctx)).isTrue
-    }
-
-    @Test
-    fun delayedCondition_with_delay() {
-        val condition = delayedCondition(1000, TimeUnit.MILLISECONDS) { true }
-        val ctx = conditionContext()
-        assertThat(condition.matches(ctx)).isTrue
-    }
-
-    @Test
-    fun asDelayedCondition_with_delayMillis() {
-        val condition = true.asDelayedCondition(1000)
-        val ctx = conditionContext()
-        assertThat(condition.matches(ctx)).isTrue
-    }
-
-    @Test
-    fun asDelayedCondition_with_delay() {
-        val condition = true.asDelayedCondition(1000, TimeUnit.MILLISECONDS)
-        val ctx = conditionContext()
-        assertThat(condition.matches(ctx)).isTrue
-    }
-
-    @Test
     fun conditionComposer() {
         val composer = conditionComposer(Operator.AND)
         val condition = composer.with(`true`(), `true`()).compose()
-        val ctx = conditionContext()
-        assertThat(condition.matches(ctx)).isTrue
-    }
-
-    @Test
-    fun completed() {
-        val condition = completed(true)
         val ctx = conditionContext()
         assertThat(condition.matches(ctx)).isTrue
     }
@@ -168,22 +71,6 @@ class ConditionalExtensionKtTest {
         val condition = `false`()
         val ctx = conditionContext()
         assertThat(condition.matches(ctx)).isFalse
-    }
-
-    @Test
-    fun failed_with_supplier() {
-        val condition = failed { RuntimeException() }
-        val ctx = conditionContext()
-        assertThatThrownBy { condition.matches(ctx) }
-            .isExactlyInstanceOf(RuntimeException::class.java)
-    }
-
-    @Test
-    fun failed_with_contextAwareSupplier() {
-        val condition = failed { _ -> RuntimeException() }
-        val ctx = conditionContext()
-        assertThatThrownBy { condition.matches(ctx) }
-            .isExactlyInstanceOf(RuntimeException::class.java)
     }
 
     @Test

--- a/conditional-kotlin/src/test/kotlin/com/linecorp/conditional/kotlin/ConditionalExtensionKtTest.kt
+++ b/conditional-kotlin/src/test/kotlin/com/linecorp/conditional/kotlin/ConditionalExtensionKtTest.kt
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.conditional.kotlin
+
+import com.linecorp.conditional.Operator
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.util.concurrent.ForkJoinPool
+import java.util.concurrent.TimeUnit
+
+class ConditionalExtensionKtTest {
+
+    @Test
+    fun condition() {
+        val condition = condition { true }
+        val ctx = conditionContext()
+        assertThat(condition.matches(ctx)).isTrue
+    }
+
+    @Test
+    fun condition_with_timeoutMillis() {
+        val condition = condition(1000) { true }
+        val ctx = conditionContext()
+        assertThat(condition.matches(ctx)).isTrue
+    }
+
+    @Test
+    fun condition_with_timeout() {
+        val condition = condition(1000, TimeUnit.MILLISECONDS) { true }
+        val ctx = conditionContext()
+        assertThat(condition.matches(ctx)).isTrue
+    }
+
+    @Test
+    fun asCondition() {
+        val condition = true.asCondition()
+        val ctx = conditionContext()
+        assertThat(condition.matches(ctx)).isTrue
+    }
+
+    @Test
+    fun asyncCondition() {
+        val condition = asyncCondition { true }
+        val ctx = conditionContext()
+        assertThat(condition.matches(ctx)).isTrue
+    }
+
+    @Test
+    fun asyncCondition_with_executor() {
+        val executor = ForkJoinPool.commonPool()
+        val condition = asyncCondition(executor) { true }
+        val ctx = conditionContext()
+        assertThat(condition.matches(ctx)).isTrue
+    }
+
+    @Test
+    fun asyncCondition_with_timeoutMillis() {
+        val condition = asyncCondition(1000) { true }
+        val ctx = conditionContext()
+        assertThat(condition.matches(ctx)).isTrue
+    }
+
+    @Test
+    fun asyncCondition_with_timeoutMillis_and_executor() {
+        val executor = ForkJoinPool.commonPool()
+        val condition = asyncCondition(1000, executor) { true }
+        val ctx = conditionContext()
+        assertThat(condition.matches(ctx)).isTrue
+    }
+
+    @Test
+    fun asyncCondition_with_timeout() {
+        val condition = asyncCondition(1000, TimeUnit.MILLISECONDS) { true }
+        val ctx = conditionContext()
+        assertThat(condition.matches(ctx)).isTrue
+    }
+
+    @Test
+    fun asyncCondition_with_timeout_and_executor() {
+        val executor = ForkJoinPool.commonPool()
+        val condition = asyncCondition(1000, TimeUnit.MILLISECONDS, executor) { true }
+        val ctx = conditionContext()
+        assertThat(condition.matches(ctx)).isTrue
+    }
+
+    @Test
+    fun asAsyncCondition() {
+        val condition = true.asAsyncCondition()
+        val ctx = conditionContext()
+        assertThat(condition.matches(ctx)).isTrue
+    }
+
+    @Test
+    fun asAsyncCondition_with_executor() {
+        val executor = ForkJoinPool.commonPool()
+        val condition = true.asAsyncCondition(executor)
+        val ctx = conditionContext()
+        assertThat(condition.matches(ctx)).isTrue
+    }
+
+    @Test
+    fun delayedCondition_with_delayMillis() {
+        val condition = delayedCondition(1000) { true }
+        val ctx = conditionContext()
+        assertThat(condition.matches(ctx)).isTrue
+    }
+
+    @Test
+    fun delayedCondition_with_delay() {
+        val condition = delayedCondition(1000, TimeUnit.MILLISECONDS) { true }
+        val ctx = conditionContext()
+        assertThat(condition.matches(ctx)).isTrue
+    }
+
+    @Test
+    fun asDelayedCondition_with_delayMillis() {
+        val condition = true.asDelayedCondition(1000)
+        val ctx = conditionContext()
+        assertThat(condition.matches(ctx)).isTrue
+    }
+
+    @Test
+    fun asDelayedCondition_with_delay() {
+        val condition = true.asDelayedCondition(1000, TimeUnit.MILLISECONDS)
+        val ctx = conditionContext()
+        assertThat(condition.matches(ctx)).isTrue
+    }
+
+    @Test
+    fun conditionComposer() {
+        val composer = conditionComposer(Operator.AND)
+        val condition = composer.with(`true`(), `true`()).compose()
+        val ctx = conditionContext()
+        assertThat(condition.matches(ctx)).isTrue
+    }
+
+    @Test
+    fun completed() {
+        val condition = completed(true)
+        val ctx = conditionContext()
+        assertThat(condition.matches(ctx)).isTrue
+    }
+
+    @Test
+    fun trueCondition() {
+        val condition = `true`()
+        val ctx = conditionContext()
+        assertThat(condition.matches(ctx)).isTrue
+    }
+
+    @Test
+    fun falseCondition() {
+        val condition = `false`()
+        val ctx = conditionContext()
+        assertThat(condition.matches(ctx)).isFalse
+    }
+
+    @Test
+    fun failed_with_supplier() {
+        val condition = failed { RuntimeException() }
+        val ctx = conditionContext()
+        assertThatThrownBy { condition.matches(ctx) }
+            .isExactlyInstanceOf(RuntimeException::class.java)
+    }
+
+    @Test
+    fun failed_with_contextAwareSupplier() {
+        val condition = failed { _ -> RuntimeException() }
+        val ctx = conditionContext()
+        assertThatThrownBy { condition.matches(ctx) }
+            .isExactlyInstanceOf(RuntimeException::class.java)
+    }
+
+    @Test
+    fun asConditionContext() {
+        val condition = condition { ctx ->
+            ctx.`var`("a") as Boolean
+        }
+        val ctx = mapOf("a" to true).asConditionContext()
+        assertThat(condition.matches(ctx)).isTrue
+    }
+}


### PR DESCRIPTION
Motivation:

Using the Kotlin DSL, we can use condition-related functions more easily.

Modifications:

- Built a Kotlin DSL for the Condition class.

Result:

- When using Kotlin, we can use the Kotlin DSL without using the Java method of the condition-related class.

<!--
All source files must begin with the following copyright header:

Copyright $today.year LINE Corporation

LINE Corporation licenses this file to you under the Apache License,
version 2.0 (the "License"); you may not use this file except in compliance
with the License. You may obtain a copy of the License at:

  https://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
License for the specific language governing permissions and limitations
under the License.
-->