### PR TITLE
Add startTime and endTime in OffsetDateTime format

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,9 +201,9 @@ condition.matches(ctx);
 for (ConditionMatchResult log : ctx.logs()) { // 👈
     System.out.println(log);
 }
-// ConditionMatchResult{condition=a, state=COMPLETED, matches=true, async=true, thread=ForkJoinPool.commonPool-worker-1, delay=0ms, timeout=INF, startTime=1672914898988ms, endTime=1672914898988ms, duration=0ms}
-// ConditionMatchResult{condition=b, state=COMPLETED, matches=false, async=true, thread=ForkJoinPool.commonPool-worker-2, delay=0ms, timeout=INF, startTime=1672914898988ms, endTime=1672914898988ms, duration=0ms}
-// ConditionMatchResult{condition=(a and b), state=COMPLETED, matches=false, async=false, thread=Test worker, delay=0ms, timeout=INF, startTime=1672914898986ms, endTime=1672914898989ms, duration=3ms}
+// ConditionMatchResult{condition=a, state=COMPLETED, matches=true, async=true, thread=ForkJoinPool.commonPool-worker-1, delay=0ms, timeout=INF, startTime=2023-01-08T19:58:03.494+09:00, endTime=2023-01-08T19:58:03.495+09:00, duration=1ms}
+// ConditionMatchResult{condition=b, state=FAILED, cause=java.lang.IllegalStateException, async=true, thread=ForkJoinPool.commonPool-worker-2, delay=0ms, timeout=INF, startTime=2023-01-08T19:58:03.495+09:00, endTime=2023-01-08T19:58:03.495+09:00, duration=0ms}
+// ConditionMatchResult{condition=(a and b), state=FAILED, cause=java.lang.IllegalStateException, async=false, thread=Test worker, delay=0ms, timeout=INF, startTime=2023-01-08T19:58:03.490+09:00, endTime=2023-01-08T19:58:03.496+09:00, duration=6ms}
 ```
 
 You can see in which thread each conditional expression was matched, how long it took, and what the result was.
@@ -222,9 +222,9 @@ try {
         System.out.println(log);
     }
 }
-// ConditionMatchResult{condition=a, state=COMPLETED, matches=true, async=true, thread=ForkJoinPool.commonPool-worker-1, delay=0ms, timeout=INF, startTime=1672914835663ms, endTime=1672914835663ms, duration=0ms}
-// ConditionMatchResult{condition=b, state=FAILED, cause=java.lang.IllegalStateException, async=true, thread=ForkJoinPool.commonPool-worker-2, delay=0ms, timeout=INF, startTime=1672914835663ms, endTime=1672914835663ms, duration=0ms}
-// ConditionMatchResult{condition=(a and b), state=FAILED, cause=java.lang.IllegalStateException, async=false, thread=Test worker, delay=0ms, timeout=INF, startTime=1672914835661ms, endTime=1672914835663ms, duration=2ms}
+// ConditionMatchResult{condition=a, state=COMPLETED, matches=true, async=true, thread=ForkJoinPool.commonPool-worker-1, delay=0ms, timeout=INF, startTime=2023-01-08T19:59:03.515+09:00, endTime=2023-01-08T19:59:03.515+09:00, duration=0ms}
+// ConditionMatchResult{condition=b, state=FAILED, cause=java.lang.IllegalStateException, async=true, thread=ForkJoinPool.commonPool-worker-2, delay=0ms, timeout=INF, startTime=2023-01-08T19:59:03.515+09:00, endTime=2023-01-08T19:59:03.516+09:00, duration=1ms}
+// ConditionMatchResult{condition=(a and b), state=FAILED, cause=java.lang.IllegalStateException, async=false, thread=Test worker, delay=0ms, timeout=INF, startTime=2023-01-08T19:59:03.511+09:00, endTime=2023-01-08T19:59:03.516+09:00, duration=5ms}
 ```
 
 ## Kotlin DSL support

--- a/conditional/src/main/java/com/linecorp/conditional/ConditionMatchResult.java
+++ b/conditional/src/main/java/com/linecorp/conditional/ConditionMatchResult.java
@@ -18,6 +18,9 @@ package com.linecorp.conditional;
 
 import static java.util.Objects.requireNonNull;
 
+import java.time.Instant;
+import java.time.ZoneId;
+
 import javax.annotation.Nullable;
 
 public final class ConditionMatchResult {
@@ -170,6 +173,10 @@ public final class ConditionMatchResult {
         return millis == Long.MAX_VALUE ? "INF" : millis + "ms";
     }
 
+    private static String millisAsISO8601String(long millis) {
+        return Instant.ofEpochMilli(millis).atZone(ZoneId.systemDefault()).toOffsetDateTime().toString();
+    }
+
     @Override
     public String toString() {
         final var builder = new StringBuilder();
@@ -184,8 +191,8 @@ public final class ConditionMatchResult {
                .append(", thread=").append(thread.getName())
                .append(", delay=").append(millisAsString(condition.delayMillis()))
                .append(", timeout=").append(millisAsString(condition.timeoutMillis()))
-               .append(", startTime=").append(millisAsString(startTimeMillis))
-               .append(", endTime=").append(millisAsString(endTimeMillis))
+               .append(", startTime=").append(millisAsISO8601String(startTimeMillis))
+               .append(", endTime=").append(millisAsISO8601String(endTimeMillis))
                .append(", duration=").append(millisAsString(durationMillis))
                .append('}');
         return builder.toString();


### PR DESCRIPTION
Motivation:

- We can check the start time and end time in the log for condition results. 
- The unit of this start time and end time is milliseconds. This is a bit difficult to read from a user's point of view.

Modifications:

- Add `startTime` and `endTime` in `OffsetDateTime` format
- Add related methods, change variable names

Result:

- Now we can also see the start and end times in the logs in normal time notation instead of milliseconds.
- It is expected that the user will be able to check the information related to the start of the condition more intuitively.
- In `ConditionMatchResult`, you can check the `OffsetDateTime` type value similarly to the way you check the `startTime` and `endTime`.

Additional info:

- If `startTime` and `endTime` in milliseconds is the intended function please comment 🙂 